### PR TITLE
fix: normalize `nondep` flag for `letE` exprs

### DIFF
--- a/Export.lean
+++ b/Export.lean
@@ -78,7 +78,7 @@ def removeMData (e : Expr) : M Expr := do
   | .lam _ d b _ =>
     pure <| e.updateLambdaE! (← removeMData d) (← removeMData b)
   | .letE _ d v b _ =>
-    pure <| e.updateLetE! (← removeMData d) (← removeMData v) (← removeMData b)
+    pure <| e.updateLet! (← removeMData d) (← removeMData v) (← removeMData b) false
   | .forallE _ d b _ =>
     pure <| e.updateForallE! (← removeMData d) (← removeMData b)
   | .proj _ _ e2 =>


### PR DESCRIPTION
The BEq implementation for Expr checks the `nondep` flag, but `nondep` does not exist as far as type checkers are concerned, so we also need to normalize these in order prevent export of duplicate expressions with different indices.